### PR TITLE
Add one-click install scripts and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 ```
 synchronizer init
 ```
-### Step:2 Pull Docker Image
-```
+### Step:2 Pull Docker Image and prepare first instance
+```bash
+docker pull cdrakep/synqchronizer:latest
 mkdir -p /root/.synchronizer-cli-instance-01
 cp -r /root/.synchronizer-cli/* /root/.synchronizer-cli-instance-01/
 ```
@@ -20,6 +21,16 @@ mkdir -p /root/.synchronizer-cli-instance-03
 cp -r /root/.synchronizer-cli/* /root/.synchronizer-cli-instance-03/
 ```
 
+### Automated setup
+
+Run the helper script to create multiple instances automatically:
+
+```bash
+bash setup_instances.sh 3
+```
+
+The numeric argument sets how many instances are created. Each instance uses a unique port starting at **3333**.
+
 ----------------------------------------------------------
 # Ensure different host ports for each instance to prevent conflicts
 ----------------------------------------------------------
@@ -27,7 +38,7 @@ cp -r /root/.synchronizer-cli/* /root/.synchronizer-cli-instance-03/
 nano /etc/systemd/system/synchronizer-cli-02.service
 ```
 [Unit]
-Description=Synchronizer Instance 01
+Description=Synchronizer Instance 02
 After=docker.service
 Requires=docker.service
 
@@ -36,17 +47,17 @@ Type=simple
 User=root
 Restart=always
 RestartSec=10
-ExecStart=/usr/bin/docker run --rm --name synchronizer-cli-01 --pull always \
+ExecStart=/usr/bin/docker run --rm --name synchronizer-cli-02 --pull always \
   --platform linux/amd64 \
   -e HTTPS_PROXY=http://proxy1.example.com:3128 \
-  -v /root/.synchronizer-cli-instance-01/config.json:/app/config.json \
-  -p 3333:3333 \
+  -v /root/.synchronizer-cli-instance-02/config.json:/app/config.json \
+  -p 3334:3333 \
   cdrakep/synqchronizer:latest \
   --depin wss://api.multisynq.io/depin \
   --sync-name synq-XXXXXXXXX \
   --launcher cli-2.6.1/docker-2025-06-07 \
-  --key <KEY_01> \
-  --wallet <WALLET_01>
+  --key <KEY_02> \
+  --wallet <WALLET_02>
 
 [Install]
 WantedBy=multi-user.target
@@ -75,41 +86,13 @@ ExecStart=/usr/bin/docker run --rm --name synchronizer-cli-03 --pull always \
   --depin wss://api.multisynq.io/depin \
   --sync-name synq-XXXXXXXXX \
   --launcher cli-2.6.1/docker-2025-06-07 \
-  --key <KEY_01> \
-  --wallet <WALLET_01>
+  --key <KEY_03> \
+  --wallet <WALLET_03>
 
 [Install]
 WantedBy=multi-user.target
 ```
 
-nano /etc/systemd/system/synchronizer-cli-03.service
-
-```
-[Unit]
-Description=Synchronizer Instance 03
-After=docker.service
-Requires=docker.service
-
-[Service]
-Type=simple
-User=root
-Restart=always
-RestartSec=10
-ExecStart=/usr/bin/docker run --rm --name synchronizer-cli-03 --pull always \
-  --platform linux/amd64 \
-  -e HTTPS_PROXY=http://proxy1.example.com:3128 \
-  -v /root/.synchronizer-cli-instance-03/config.json:/app/config.json \
-  -p 3335:3333 \
-  cdrakep/synqchronizer:latest \
-  --depin wss://api.multisynq.io/depin \
-  --sync-name synq-XXXXXXXXX \
-  --launcher cli-2.6.1/docker-2025-06-07 \
-  --key <KEY_01> \
-  --wallet <WALLET_01>
-
-[Install]
-WantedBy=multi-user.target
-```
 
 ```
 sudo systemctl daemon-reload

--- a/install_synchronizer.sh
+++ b/install_synchronizer.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Simple installer for synchronizer-cli
+set -e
+
+arrow="\xE2\x9E\x9C" # arrow symbol
+yellow="\033[1;33m"
+red="\033[0;31m"
+reset="\033[0m"
+
+spinner() {
+    pid=$1
+    spin='|/-\\'
+    i=0
+    while kill -0 $pid 2>/dev/null; do
+        i=$(( (i+1) %4 ))
+        printf "\r[%c]" "${spin:$i:1}"
+        sleep .1
+    done
+    printf "\r"
+}
+
+install_synchronizer() {
+    if ! command -v synchronizer &>/dev/null; then
+        echo -e "${arrow} ${yellow}Installing synchronizer...${reset}"
+        (npm install -g synchronizer-cli >/dev/null 2>&1) & spinner $!
+    fi
+
+    echo -e "${arrow} ${yellow}Initializing synchronizer...${reset}"
+    (synchronizer init >/dev/null 2>&1 || \
+        echo -e "${red}Initialization skipped or failed (already initialized?).${reset}") & spinner $!
+    wait
+}
+
+install_synchronizer
+
+echo -e "${arrow} ${yellow}Installation complete.${reset}"

--- a/setup_instances.sh
+++ b/setup_instances.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Automate creation of multiple synchronizer instances
+set -e
+
+NUM_INSTANCES=${1:-3}
+BASE_PORT=3333
+
+for i in $(seq 1 "$NUM_INSTANCES"); do
+    inst=$(printf "%02d" "$i")
+    inst_dir="/root/.synchronizer-cli-instance-${inst}"
+
+    echo "Initializing instance ${inst}..."
+    synchronizer init
+
+    mkdir -p "$inst_dir"
+    cp -r /root/.synchronizer-cli/* "$inst_dir/"
+
+    port=$((BASE_PORT + i - 1))
+    service_file="/etc/systemd/system/synchronizer-cli-${inst}.service"
+
+    cat <<SERVICE > "$service_file"
+[Unit]
+Description=Synchronizer Instance ${inst}
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+User=root
+Restart=always
+RestartSec=10
+ExecStart=/usr/bin/docker run --rm --name synchronizer-cli-${inst} --pull always \
+  --platform linux/amd64 \
+  -v ${inst_dir}/config.json:/app/config.json \
+  -p ${port}:3333 \
+  cdrakep/synqchronizer:latest \
+  --depin wss://api.multisynq.io/depin \
+  --sync-name synq-XXXXXXXXX \
+  --launcher cli-2.6.1/docker-2025-06-07 \
+  --key <KEY_${inst}> \
+  --wallet <WALLET_${inst}>
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+done
+
+systemctl daemon-reload

--- a/syncronizer.md
+++ b/syncronizer.md
@@ -4,8 +4,9 @@
 ```
 synchronizer init
 ```
-### Step:2 Pull Docker Image
-```
+### Step:2 Pull Docker Image and prepare first instance
+```bash
+docker pull cdrakep/synqchronizer:latest
 mkdir -p /root/.synchronizer-cli-instance-01
 cp -r /root/.synchronizer-cli/* /root/.synchronizer-cli-instance-01/
 ```
@@ -20,6 +21,16 @@ mkdir -p /root/.synchronizer-cli-instance-03
 cp -r /root/.synchronizer-cli/* /root/.synchronizer-cli-instance-03/
 ```
 
+### Automated setup
+
+Run the helper script to create multiple instances automatically:
+
+```bash
+bash setup_instances.sh 3
+```
+
+The numeric argument sets how many instances are created. Each instance uses a unique port starting at **3333**.
+
 ----------------------------------------------------------
 # Ensure different host ports for each instance to prevent conflicts
 ----------------------------------------------------------
@@ -27,7 +38,7 @@ cp -r /root/.synchronizer-cli/* /root/.synchronizer-cli-instance-03/
 nano /etc/systemd/system/synchronizer-cli-02.service
 ```
 [Unit]
-Description=Synchronizer Instance 01
+Description=Synchronizer Instance 02
 After=docker.service
 Requires=docker.service
 
@@ -36,17 +47,17 @@ Type=simple
 User=root
 Restart=always
 RestartSec=10
-ExecStart=/usr/bin/docker run --rm --name synchronizer-cli-01 --pull always \
+ExecStart=/usr/bin/docker run --rm --name synchronizer-cli-02 --pull always \
   --platform linux/amd64 \
   -e HTTPS_PROXY=http://proxy1.example.com:3128 \
-  -v /root/.synchronizer-cli-instance-01/config.json:/app/config.json \
-  -p 3333:3333 \
+  -v /root/.synchronizer-cli-instance-02/config.json:/app/config.json \
+  -p 3334:3333 \
   cdrakep/synqchronizer:latest \
   --depin wss://api.multisynq.io/depin \
   --sync-name synq-XXXXXXXXX \
   --launcher cli-2.6.1/docker-2025-06-07 \
-  --key <KEY_01> \
-  --wallet <WALLET_01>
+  --key <KEY_02> \
+  --wallet <WALLET_02>
 
 [Install]
 WantedBy=multi-user.target
@@ -75,41 +86,13 @@ ExecStart=/usr/bin/docker run --rm --name synchronizer-cli-03 --pull always \
   --depin wss://api.multisynq.io/depin \
   --sync-name synq-XXXXXXXXX \
   --launcher cli-2.6.1/docker-2025-06-07 \
-  --key <KEY_01> \
-  --wallet <WALLET_01>
+  --key <KEY_03> \
+  --wallet <WALLET_03>
 
 [Install]
 WantedBy=multi-user.target
 ```
 
-nano /etc/systemd/system/synchronizer-cli-03.service
-
-```
-[Unit]
-Description=Synchronizer Instance 03
-After=docker.service
-Requires=docker.service
-
-[Service]
-Type=simple
-User=root
-Restart=always
-RestartSec=10
-ExecStart=/usr/bin/docker run --rm --name synchronizer-cli-03 --pull always \
-  --platform linux/amd64 \
-  -e HTTPS_PROXY=http://proxy1.example.com:3128 \
-  -v /root/.synchronizer-cli-instance-03/config.json:/app/config.json \
-  -p 3335:3333 \
-  cdrakep/synqchronizer:latest \
-  --depin wss://api.multisynq.io/depin \
-  --sync-name synq-XXXXXXXXX \
-  --launcher cli-2.6.1/docker-2025-06-07 \
-  --key <KEY_01> \
-  --wallet <WALLET_01>
-
-[Install]
-WantedBy=multi-user.target
-```
 
 ```
 sudo systemctl daemon-reload


### PR DESCRIPTION
## Summary
- fix service descriptions and remove duplicates
- add `install_synchronizer.sh` for installing and initializing the CLI
- add `setup_instances.sh` script for automated multi-instance creation
- clarify Docker pull step
- document automated setup in README and syncronizer guide

## Testing
- `bash -n install_synchronizer.sh`
- `bash -n setup_instances.sh`


------
https://chatgpt.com/codex/tasks/task_e_68482cb58c20832698f0e6c6814bb83b